### PR TITLE
Windows-friendly handler file names 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In your start script:
 
 The route folder is expected to contain routes handlers, the names of which are directly derived from the path it should serve, as follows:
 
-GET /path/to/{some}/resource/{id} => ~path~to~:some~resource~:id~get.js
+`GET /path/to/{some}/resource/{id}` => `~path~to~:some~resource~:id~get.js`
 
 (where _some_ and _id_ are path parameters)
 
@@ -150,4 +150,27 @@ The addUtil method can be used to add your own, custom utilities to the _utils_ 
                deconstruct.start ( process.env.PORT || 8080 );
            } );
    }
+```
+
+### Windows support
+
+In Windows the `:` character is not a valid character in file names, so alternatively the route files can use a different character (or string) e.g:
+
+`~path~to~__some~resource~__id~get.js`
+
+and then use `loadRoutes` like this:
+
+```js
+  const dapi = require ( 'deconstruct-api' );
+  
+  dapi.loadRoutes ( {
+    routeDir: path.resolve ( './my-routes' ), 
+    pathParameterFlag: '__'
+  }, error => {
+    if ( error ) {
+      return console.error ( error );
+    }
+    
+    dapi.start ( process.env.PORT );
+  } );
 ```

--- a/deconstruct.js
+++ b/deconstruct.js
@@ -199,16 +199,8 @@ module.exports = {
     setSecretRetriever: secretRetriever => utils.auth.getIssuerSecret = secretRetriever,
     addUtil: ( name, util ) => { utils[name] = util; },
     loadRoutes: ( options, callback ) => {
-        const routeDir = options;
-        const pathParameterFlag = ':';
-
-        if (typeof options === 'object') {
-            routeDir = options.routeDir;
-            
-            if (typeof options.pathParameterFlag === 'string') {
-                pathParameterFlag = options.pathParameterFlag;
-            }
-        }
+        const routeDir = typeof options === 'object' ? options.routeDir : options;
+        const pathParameterFlag = typeof options === 'object' && options.pathParameterFlag ? options.pathParameterFlag : ':';
 
         rDir.path = path.resolve ( routeDir );
 
@@ -262,12 +254,13 @@ module.exports = {
                 return R.concat ( reduced, [ route, `${corrPreFlightRoute ( route )}-${method}` ] );
             }, [], routes ) )
             .sequence ()
-            .doto ( route => {
-                const routeComponents = route.replace ( /\.js$/, '' ).split ( '~' );
+            .doto ( routeFileName => {
+                const routeComponents = routeFileName.replace ( /\.js$/, '' ).split ( '~' )
+                    .map( component => component.replace(pathParameterFlag, ':') );
                 const pathSpec = R.init ( routeComponents ).join ( '/' );
                 const method = R.last ( routeComponents );
 
-                ( ( pathSpec, route, method ) => {
+                ( ( pathSpec, routeFileName, method ) => {
                     if ( method.match ( 'preflight' ) ) {
                         const methods = R.concat ( R.tail ( method.split ( '-' ) ), method.match ( 'get' ) ? [ 'head' ] : [] );
                         const methodHeader = R.map ( method => method.toUpperCase (), methods ).join ( ', ' );
@@ -280,14 +273,14 @@ module.exports = {
                         } );
                     }
 
-                    const routeHandler = require ( `${routeDir}/${route}` )( utils );
+                    const routeHandler = require ( `${routeDir}/${routeFileName}` )( utils );
 
                     if ( method.toLowerCase () === 'get' ) {
                         console.log ( `registering ${pathSpec} HEAD` );
 
                         app.head ( pathSpec, ( req, res ) => {
                             log ( 1, `HEAD ${pathSpec}` );
-                            return utils.streamRoute ( route, utils, req, res )
+                            return utils.streamRoute ( routeFileName, utils, req, res )
                                 .toCallback ( ( error, response ) => {
                                     if ( error ) {
                                         return utils.error ( res, error );
@@ -301,7 +294,7 @@ module.exports = {
 
                         return app.get ( pathSpec, ( req, res ) => {
                             log ( 1, `GET ${pathSpec}` );
-                            return utils.streamRoute ( route, utils, req, res )
+                            return utils.streamRoute ( routeFileName, utils, req, res )
                                 .toCallback ( ( error, response ) => {
                                     if ( error ) {
                                         return utils.error ( res, error );
@@ -320,7 +313,7 @@ module.exports = {
                         log ( 1, `${method.toUpperCase()} ${pathSpec}` );
                         return routeHandler ( req, res );
                     } );
-                } )( pathSpec, route, method );
+                } )( pathSpec, routeFileName, method );
             } )
             .collect ()
             .toCallback ( callback );

--- a/deconstruct.js
+++ b/deconstruct.js
@@ -199,7 +199,7 @@ module.exports = {
     setSecretRetriever: secretRetriever => utils.auth.getIssuerSecret = secretRetriever,
     addUtil: ( name, util ) => { utils[name] = util; },
     loadRoutes: ( options, callback ) => {
-        const routeDir = typeof options === 'object' ? (options.routeDir || './routes') : (options || './routes');
+        const routeDir = (typeof options === 'object' ? options.routeDir : options) || './routes';
         const pathParameterFlag = typeof options === 'object' && options.pathParameterFlag ? options.pathParameterFlag : ':';
 
         rDir.path = path.resolve ( routeDir );

--- a/deconstruct.js
+++ b/deconstruct.js
@@ -198,7 +198,18 @@ app.use ( ( req, res, next ) => {
 module.exports = {
     setSecretRetriever: secretRetriever => utils.auth.getIssuerSecret = secretRetriever,
     addUtil: ( name, util ) => { utils[name] = util; },
-    loadRoutes: ( routeDir, callback ) => {
+    loadRoutes: ( options, callback ) => {
+        const routeDir = options;
+        const pathParameterFlag = ':';
+
+        if (typeof options === 'object') {
+            routeDir = options.routeDir;
+            
+            if (typeof options.pathParameterFlag === 'string') {
+                pathParameterFlag = options.pathParameterFlag;
+            }
+        }
+
         rDir.path = path.resolve ( routeDir );
 
         return dirStream ( routeDir )
@@ -209,7 +220,7 @@ module.exports = {
                             return memo;
                         }
 
-                        if ( component.match ( ':' ) ) {
+                        if ( component.match ( pathParameterFlag ) ) {
                             return {
                                 index: memo.index,
                                 found: true

--- a/deconstruct.js
+++ b/deconstruct.js
@@ -199,7 +199,7 @@ module.exports = {
     setSecretRetriever: secretRetriever => utils.auth.getIssuerSecret = secretRetriever,
     addUtil: ( name, util ) => { utils[name] = util; },
     loadRoutes: ( options, callback ) => {
-        const routeDir = typeof options === 'object' ? options.routeDir : options;
+        const routeDir = typeof options === 'object' ? (options.routeDir || './routes') : (options || './routes');
         const pathParameterFlag = typeof options === 'object' && options.pathParameterFlag ? options.pathParameterFlag : ':';
 
         rDir.path = path.resolve ( routeDir );


### PR DESCRIPTION
as per #1 

Also renamed `route` to `routeFileName` to make it clear it does not refer to the routes in express, and added some doc